### PR TITLE
Update PIP version used in release script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
             echo "Deploy release"
             python -m venv ../venv
             . ../venv/bin/activate
+            pip install --upgrade pip
             pip install twine
             ls dist
             twine upload -u __token__ -p $PYPI_PASSWORD --skip-existing dist/*


### PR DESCRIPTION
Following the suggestion of the CircleCI report on the failed run of the
release, update PIP to the latest to pass the "build_rust step.