### PR TITLE
Update to CastXML 0.4.3

### DIFF
--- a/CastXMLUrls.cmake
+++ b/CastXMLUrls.cmake
@@ -14,6 +14,7 @@ set(macosx_binary_sha512 "4a6ca04003d94a09a9dd3226d1f5a4a420db3fb2eb5fb63549fe94
 set(win64_binary_url    "https://data.kitware.com/api/v1/file/607f0d192fa25629b9f667fe/download")
 set(win64_binary_sha512 "82ff5a23f385a0fddcd76c62fa109eb3cd087d6ba61ff0bdcd55a31341bdf2b383446260d53a4d2fac7d778f4d29c383de0429804d2050f0fb743e44c315fd94")
 
+# Package 64-bit binaries as the 32-bit ones.
 # See https://github.com/CastXML/CastXML-python-distributions/issues/5
 set(win32_binary_url    "${win64_binary_url}")
 set(win32_binary_sha512 "${win64_binary_sha512}")

--- a/CastXMLUrls.cmake
+++ b/CastXMLUrls.cmake
@@ -5,14 +5,14 @@
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha512 "NA")
 
-set(linux64_binary_url    "https://data.kitware.com/api/v1/file/6006edd02fa25629b9fca6a6/download")
-set(linux64_binary_sha512 "bdbb67a10c5f8d1b738cd19cb074f409d4803e8077cb8c1072ef4eaf738fa871a73643f9c8282d58cae28d188df842c82ad6620b6d590b0396a0172a27438dce")
+set(linux64_binary_url    "https://data.kitware.com/api/v1/file/607f0cd12fa25629b9f667ce/download")
+set(linux64_binary_sha512 "1610df48287cc67cc9bf46c23c5fe0d26d1d98868041993f36670d9485b5f7126b702dfd6437760199d2f92dea0e527c32cae47dc399a17ce191e7cb9521a2cf")
 
-set(macosx_binary_url    "https://data.kitware.com/api/v1/file/6006eda52fa25629b9fca696/download")
-set(macosx_binary_sha512 "5d937e938f7b882a3a3e7941e68f8312d0898aaf2082e00003dd362b1ba70b98b0a08706a1be28e71652a6a0f1e66f89768b5eaa20e5a100592d5b3deefec3f0")
+set(macosx_binary_url    "https://data.kitware.com/api/v1/file/607f0ceb2fa25629b9f667de/download")
+set(macosx_binary_sha512 "4a6ca04003d94a09a9dd3226d1f5a4a420db3fb2eb5fb63549fe9469afe39bf728cfc35b80e723764f2dd106faffe480afc0fb175cd5ec6b9971efa1422632d1")
 
-set(win64_binary_url    "https://data.kitware.com/api/v1/file/6006ed812fa25629b9fca68a/download")
-set(win64_binary_sha512 "bdd1e2c3b203019f758681067bb4dd68cb37abc930fee6b4b5d181bd805236352f888d061f32c7f93bde2eac2caa1265b93bbccff6656f98989dafd08f55847b")
+set(win64_binary_url    "https://data.kitware.com/api/v1/file/607f0d192fa25629b9f667fe/download")
+set(win64_binary_sha512 "82ff5a23f385a0fddcd76c62fa109eb3cd087d6ba61ff0bdcd55a31341bdf2b383446260d53a4d2fac7d778f4d29c383de0429804d2050f0fb743e44c315fd94")
 
 # See https://github.com/CastXML/CastXML-python-distributions/issues/5
 set(win32_binary_url    "${win64_binary_url}")

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Introduction
 ============
 
-The latest CastXML python wheels provide CastXML 0.4.2 executable.
+The latest CastXML python wheels provide CastXML 0.4.3 executable.
 
 CastXML is a C-family abstract syntax tree XML output tool.
 

--- a/docs/update_castxml_version.rst
+++ b/docs/update_castxml_version.rst
@@ -16,13 +16,13 @@ Available CastXML archives can be found `here <https://data.kitware.com/#folder/
 2. Execute `scripts/update_castxml_version.py` command line tool with the desired
    ``X.Y.Z`` CastXML version available for download. For example::
 
-    $ release=0.4.2
+    $ release=0.4.3
     $ python scripts/update_castxml_version.py ${release}
 
     Collecting URLs and SHAs from 'https://data.kitware.com/#folder/57b5de948d777f10f2696370'
     Collecting URLs and SHAs from 'https://data.kitware.com/#folder/57b5de948d777f10f2696370' - done
-    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.2
-    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.2 - done
+    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.3
+    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.3 - done
     Updating README.md
     Updating README.md - done
     Updating docs/update_castxml_version.rst
@@ -33,7 +33,7 @@ Available CastXML archives can be found `here <https://data.kitware.com/#folder/
 3. Create a topic named `update-to-castxml-X.Y.Z` and commit the changes.
    For example::
 
-    release=0.4.2
+    release=0.4.3
     git checkout -b update-to-castxml-${release}
     git add CastXMLUrls.cmake README.md docs/update_castxml_version.rst tests/test_distribution.py
     git commit -m "Update to CastXML ${release}"

--- a/scripts/update_castxml_version.py
+++ b/scripts/update_castxml_version.py
@@ -45,9 +45,9 @@ def get_archive_urls_and_shas(version, verbose=False):
         items = gc.listItem(archive_folder_ids[0])
 
         expected_files = {
-            "castxml-linux.tar.gz":  "linux64_binary",
-            "castxml-macosx.tar.gz": "macosx_binary",
-            "castxml-windows.zip":   "win64_binary",
+            "castxml-linux-amd64.tar.gz":  "linux64_binary",
+            "castxml-macosx-amd64.tar.gz": "macosx_binary",
+            "castxml-windows-amd64.zip":   "win64_binary",
         }
 
         # Get download URL and SHA512 for each file
@@ -90,11 +90,12 @@ def generate_cmake_variables(urls_and_shas):
       set(macosx_binary_url    "{macosx_binary_url}")
       set(macosx_binary_sha512 "{macosx_binary_sha512}")
 
-      set(win32_binary_url    "NA")  # Windows 32-bit binaries not available
-      set(win32_binary_sha512 "NA")
-
       set(win64_binary_url    "{win64_binary_url}")
       set(win64_binary_sha512 "{win64_binary_sha512}")
+
+      # See https://github.com/CastXML/CastXML-python-distributions/issues/5
+      set(win32_binary_url    "${{win64_binary_url}}")
+      set(win32_binary_sha512 "${{win64_binary_sha512}}")
     """).format(**template_inputs)
 
     return cmake_variables

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -8,7 +8,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_castxml_install(virtualenv, tmpdir):
-    expected_version = "0.4.2"
+    expected_version = "0.4.3"
 
     for executable_name in ["castxml"]:
         output = virtualenv.run(


### PR DESCRIPTION
Also, update file names for targeted version as ARM versions are now
available from the data.kitware.com download site.

Update formatting to contain previously manual changes.