### PR TITLE
Update to CastXML 0.4.4

### DIFF
--- a/CastXMLUrls.cmake
+++ b/CastXMLUrls.cmake
@@ -5,16 +5,15 @@
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha512 "NA")
 
-set(linux64_binary_url    "https://data.kitware.com/api/v1/file/607f0cd12fa25629b9f667ce/download")
+set(linux64_binary_url    "https://data.kitware.com/api/v1/file/617851882fa25629b9af3964/download")
 set(linux64_binary_sha512 "1610df48287cc67cc9bf46c23c5fe0d26d1d98868041993f36670d9485b5f7126b702dfd6437760199d2f92dea0e527c32cae47dc399a17ce191e7cb9521a2cf")
 
-set(macosx_binary_url    "https://data.kitware.com/api/v1/file/607f0ceb2fa25629b9f667de/download")
+set(macosx_binary_url    "https://data.kitware.com/api/v1/file/6178517f2fa25629b9af395a/download")
 set(macosx_binary_sha512 "4a6ca04003d94a09a9dd3226d1f5a4a420db3fb2eb5fb63549fe9469afe39bf728cfc35b80e723764f2dd106faffe480afc0fb175cd5ec6b9971efa1422632d1")
 
-set(win64_binary_url    "https://data.kitware.com/api/v1/file/607f0d192fa25629b9f667fe/download")
+set(win64_binary_url    "https://data.kitware.com/api/v1/file/617851942fa25629b9af396e/download")
 set(win64_binary_sha512 "82ff5a23f385a0fddcd76c62fa109eb3cd087d6ba61ff0bdcd55a31341bdf2b383446260d53a4d2fac7d778f4d29c383de0429804d2050f0fb743e44c315fd94")
 
-# Package 64-bit binaries as the 32-bit ones.
 # See https://github.com/CastXML/CastXML-python-distributions/issues/5
 set(win32_binary_url    "${win64_binary_url}")
 set(win32_binary_sha512 "${win64_binary_sha512}")

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Introduction
 ============
 
-The latest CastXML python wheels provide CastXML 0.4.3 executable.
+The latest CastXML python wheels provide CastXML 0.4.4 executable.
 
 CastXML is a C-family abstract syntax tree XML output tool.
 

--- a/docs/update_castxml_version.rst
+++ b/docs/update_castxml_version.rst
@@ -16,13 +16,13 @@ Available CastXML archives can be found `here <https://data.kitware.com/#folder/
 2. Execute `scripts/update_castxml_version.py` command line tool with the desired
    ``X.Y.Z`` CastXML version available for download. For example::
 
-    $ release=0.4.3
+    $ release=0.4.4
     $ python scripts/update_castxml_version.py ${release}
 
     Collecting URLs and SHAs from 'https://data.kitware.com/#folder/57b5de948d777f10f2696370'
     Collecting URLs and SHAs from 'https://data.kitware.com/#folder/57b5de948d777f10f2696370' - done
-    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.3
-    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.3 - done
+    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.4
+    Updating 'CastXMLUrls.cmake' with CastXML version 0.4.4 - done
     Updating README.md
     Updating README.md - done
     Updating docs/update_castxml_version.rst
@@ -33,7 +33,7 @@ Available CastXML archives can be found `here <https://data.kitware.com/#folder/
 3. Create a topic named `update-to-castxml-X.Y.Z` and commit the changes.
    For example::
 
-    release=0.4.3
+    release=0.4.4
     git checkout -b update-to-castxml-${release}
     git add CastXMLUrls.cmake README.md docs/update_castxml_version.rst tests/test_distribution.py
     git commit -m "Update to CastXML ${release}"

--- a/scripts/update_castxml_version.py
+++ b/scripts/update_castxml_version.py
@@ -45,9 +45,9 @@ def get_archive_urls_and_shas(version, verbose=False):
         items = gc.listItem(archive_folder_ids[0])
 
         expected_files = {
-            "castxml-linux-amd64.tar.gz":  "linux64_binary",
-            "castxml-macosx-amd64.tar.gz": "macosx_binary",
-            "castxml-windows-amd64.zip":   "win64_binary",
+            "castxml-linux.tar.gz":  "linux64_binary",
+            "castxml-macosx.tar.gz": "macosx_binary",
+            "castxml-windows.zip":   "win64_binary",
         }
 
         # Get download URL and SHA512 for each file

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -8,7 +8,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_castxml_install(virtualenv, tmpdir):
-    expected_version = "0.4.3"
+    expected_version = "0.4.4"
 
     for executable_name in ["castxml"]:
         output = virtualenv.run(


### PR DESCRIPTION
Remove "-amd64" postfix as they aren't found by default in the
Girder folder.